### PR TITLE
Check nytprof errors

### DIFF
--- a/lib/Dancer/Plugin/NYTProf.pm
+++ b/lib/Dancer/Plugin/NYTProf.pm
@@ -156,8 +156,17 @@ get '/nytprof/:filename' => sub {
     );
     if (! -f Dancer::FileUtils::path($htmldir, 'index.html')) {
         # TODO: scrutinise this very carefully to make sure it's not
-        # exploitable; check for failure
-        system('nytprofhtml', "--file=$profiledata", "--out=$htmldir");
+        # exploitable
+        system($nytprofhtml, "--file=$profiledata", "--out=$htmldir");
+
+        if ($? == -1) {
+            die "'$nytprofhtml' failed to execute: $!";
+        } elsif ($? & 127) {
+            die "'$nytprofhtml' died with signal %d, %s coredump",
+                ($? & 127), ($? & 128) ? 'with' : 'without';
+        } else {
+            die "'$nytprofhtml' exited with value %d", $? >> 8;
+        }
     }
 
     # Redirect off to view it:

--- a/lib/Dancer/Plugin/NYTProf.pm
+++ b/lib/Dancer/Plugin/NYTProf.pm
@@ -38,6 +38,10 @@ development environment.
 
 =cut
 
+my $nytprofhtml = 'nytprofhtml';
+if (system("which $nytprofhtml > /dev/null") != 0) {
+    die "Could not find '$nytprofhtml' in the path.";
+}
 
 my $setting = plugin_setting;
 


### PR DESCRIPTION
This checks for nytprofhtml in the path (it tripped me up when I didn't have it), and also checks the return status of nytprofhtml.

The Dancer::Plugin::NYTProf module will die if any of the above checks fail.
