### PR TITLE
Sort profiles in display page

### DIFF
--- a/lib/Dancer/Plugin/NYTProf.pm
+++ b/lib/Dancer/Plugin/NYTProf.pm
@@ -142,7 +142,13 @@ produced by <tt>Devel::NYTProf</tt>.</p>
 <ul>
 LISTSTART
 
-    for my $file (@files) {
+    for my $file (
+        sort {
+            (stat Dancer::FileUtils::path($setting->{profdir},$b))->ctime
+            <=>
+            (stat Dancer::FileUtils::path($setting->{profdir},$a))->ctime
+        } @files
+    ) {
         my $fullfilepath = Dancer::FileUtils::path($setting->{profdir}, $file);
         my $label = $file;
         $label =~ s{nytprof\.out\.}{};


### PR DESCRIPTION
order by timestamp of profile descending

Currently the profiles have no order, so here's a basic sort on the timestamp of the profile with most recent first.
