### PR TITLE
adding extra resources information

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,16 +12,20 @@ WriteMakefile(
       : ()),
     PL_FILES            => {},
     PREREQ_PM => {
-        'Test::More' => 0,
-        'Dancer'     => 1.3060,
+        'Test::More'     => 0,
+        'Dancer'         => 1.3060,
         'Devel::NYTProf' => 0,
-        'File::Which' => 0,
+        'File::Which'    => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Dancer-Plugin-NYTProf-*' },
     META_MERGE => {
         'meta-spec' => { version => 2 },
         resources => {
+            license     => [ 'http://dev.perl.org/licenses/' ],
+            bugtracker  => {
+                web => 'https://github.com/bigpresh/Dancer-Plugin-NYTProf/issues',
+            },
             repository => {
                 type => 'git',
                 url  => 'https://github.com/bigpresh/Dancer-Plugin-NYTProf.git',


### PR DESCRIPTION
Hey there!

Great module! I'm using it a lot at the moment, so I wanted to provide a couple of patches I've been working on. This one in particular should (hopefully) let MetaCPAN figure out that issues should be sent here instead of to RT. Since this is what's happening now, and since you do have proper meta information regarding the github repository (though it's not yet published =/), I thought it might be useful to others like me who want to find your repository and contribute to it!

Hope this helps :)
